### PR TITLE
Reduction of superfluous code for padding

### DIFF
--- a/src/dataset.py
+++ b/src/dataset.py
@@ -20,17 +20,13 @@ class BERTDataset:
             review,
             None,
             add_special_tokens=True,
-            max_length=self.max_len
+            max_length=self.max_len,
+            pad_to_max_length=True
         )
 
         ids = inputs["input_ids"]
         mask = inputs["attention_mask"]
         token_type_ids = inputs["token_type_ids"]
-
-        padding_length = self.max_len - len(ids)
-        ids = ids + ([0] * padding_length)
-        mask = mask + ([0] * padding_length)
-        token_type_ids = token_type_ids + ([0] * padding_length)
 
         return {
             'ids': torch.tensor(ids, dtype=torch.long),


### PR DESCRIPTION
The `encode_plus()` function accepts `pad_to_max_length` as an argument. If it is set to _true_, the input is encoded with automatic padding for _ids, mask_ and _token type ids_. This can shorten 4 lines of extra code in the `BERTDataset` class to 1. 